### PR TITLE
fix: format the repository url to extrat

### DIFF
--- a/src/app/services/repository.service.spec.ts
+++ b/src/app/services/repository.service.spec.ts
@@ -2,6 +2,7 @@ import { TestBed } from '@angular/core/testing';
 
 import { RepositoryService } from './repository.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { FormControl } from '@angular/forms';
 
 describe('RepositoryService', () => {
   let service: RepositoryService;
@@ -15,5 +16,16 @@ describe('RepositoryService', () => {
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('should extract the repository name', () => {
+    // Given
+    let spy = jest.spyOn(service, 'loadRepositoryInfo');
+
+    // When
+    service.repositoryValidator()(new FormControl('https://github.com/kerhub/issue-forms-creator'));
+
+    // Then
+    expect(spy).toHaveBeenCalledWith('kerhub/issue-forms-creator');
   });
 });

--- a/src/app/services/repository.service.ts
+++ b/src/app/services/repository.service.ts
@@ -53,7 +53,8 @@ export class RepositoryService {
   repositoryValidator(): AsyncValidatorFn {
     return (control: AbstractControl): Observable<ValidationErrors | null> => {
       control.markAllAsTouched();
-      return this.loadRepositoryInfo(control.value).pipe(
+      const repositoryName = this.extractRepositoryName(control.value);
+      return this.loadRepositoryInfo(repositoryName).pipe(
         map(() => null),
         catchError((error: HttpErrorResponse) => {
           this.repositorySubject.next(null);
@@ -61,6 +62,11 @@ export class RepositoryService {
         }),
       );
     };
+  }
+
+  private extractRepositoryName(url: string): string {
+    const githubDomain = 'https://github.com/';
+    return url.replace(githubDomain, '');
   }
 
   updateRepository(repository: string): void {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/geromegrignon/issue-forms-creator/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
the complete URL of a GitHub repository is not valid as it expects the organization/repository format

Issue Number: #17 


## What is the new behavior?
The organization and the repository are extracted from a whole url.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
