### PR TITLE
fix: move required checkbox property to root level

### DIFF
--- a/src/app/features/issue-creator/list-option/list-option.component.html
+++ b/src/app/features/issue-creator/list-option/list-option.component.html
@@ -20,6 +20,10 @@
     <label for="required-field">required</label>
     <input id="required-field" type="checkbox" formControlName="required" />
   </article>
+  <article class="field" *ngIf="form.get('required')">
+    <label for="option-required-field">required</label>
+    <input id="option-required-field" type="checkbox" formControlName="required" />
+  </article>
 </section>
 <button
   [disabled]="!removable"

--- a/src/app/features/issue-preview/checkboxes-preview/checkboxes-preview.component.html
+++ b/src/app/features/issue-preview/checkboxes-preview/checkboxes-preview.component.html
@@ -15,11 +15,11 @@
   [errorMessage]="formGroup.get('attributes')?.get('options')?.getError('duplicateLabels').message"
 ></app-error-message>
 <section *ngFor="let option of section.attributes.options; let i = index">
-  <input [id]="i" type="checkbox" [required]="option.validations?.required" disabled />
+  <input [id]="i" type="checkbox" [required]="option.required" disabled />
   <label [for]="i">
     <span *ngIf="option.label; else missingCheckboxLabel">
       {{ option.label }}
-      <span class="required-marker" *ngIf="option.validations?.required">*</span>
+      <span class="required-marker" *ngIf="option.required">*</span>
     </span>
     <ng-template #missingCheckboxLabel>
       <app-error-message

--- a/src/app/forms/issue.form.spec.ts
+++ b/src/app/forms/issue.form.spec.ts
@@ -62,15 +62,11 @@ describe('IssueForm', () => {
         options: [
           {
             label: 'foo',
-            validations: {
-              required: true,
-            },
+            required: true,
           },
           {
             label: 'foo',
-            validations: {
-              required: true,
-            },
+            required: true,
           },
         ],
       },
@@ -98,15 +94,11 @@ describe('IssueForm', () => {
         options: [
           {
             label: 'foo',
-            validations: {
-              required: true,
-            },
+            required: true,
           },
           {
             label: 'bar',
-            validations: {
-              required: true,
-            },
+            required: true,
           },
         ],
       },
@@ -134,15 +126,11 @@ describe('IssueForm', () => {
         options: [
           {
             label: 'foo',
-            validations: {
-              required: true,
-            },
+            required: true,
           },
           {
             label: ' foo',
-            validations: {
-              required: true,
-            },
+            required: true,
           },
         ],
       },
@@ -345,9 +333,7 @@ describe('IssueForm', () => {
         options: [
           {
             label: '',
-            validations: {
-              required: true,
-            },
+            required: true,
           },
         ],
       },
@@ -374,9 +360,7 @@ describe('IssueForm', () => {
         options: [
           {
             label: 'foo',
-            validations: {
-              required: true,
-            },
+            required: true,
           },
         ],
       },
@@ -772,9 +756,7 @@ describe('IssueForm', () => {
         options: [
           {
             label: 'do it',
-            validations: {
-              required: false,
-            },
+            required: false,
           },
         ],
       },
@@ -799,9 +781,7 @@ describe('IssueForm', () => {
         options: [
           {
             label: 'do it',
-            validations: {
-              required: false,
-            },
+            required: false,
           },
         ],
       },
@@ -846,15 +826,11 @@ describe('IssueForm', () => {
         options: [
           {
             label: 'do it',
-            validations: {
-              required: false,
-            },
+            required: false,
           },
           {
             label: 'do it',
-            validations: {
-              required: false,
-            },
+            required: false,
           },
         ],
       },

--- a/src/app/forms/issue.form.ts
+++ b/src/app/forms/issue.form.ts
@@ -163,9 +163,7 @@ export class IssueForm extends FormGroup {
   private createCheckbox(data?: Partial<CheckboxSection>): FormGroup {
     return new FormGroup({
       label: new FormControl(data?.label || null, Validators.required),
-      validations: new FormGroup({
-        required: new FormControl(data?.validations?.required || false),
-      }),
+      required: new FormControl(data?.required || false),
     });
   }
 

--- a/src/app/models/checkbox-section.ts
+++ b/src/app/models/checkbox-section.ts
@@ -1,6 +1,4 @@
 export interface CheckboxSection {
   label: string;
-  validations: {
-    required: boolean;
-  };
+  required: boolean;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/geromegrignon/issue-forms-creator/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Checkbox required state is nested in `validations`property.

Issue Number: #20 


## What is the new behavior?
the `required`state is now at the root level of the checkbox definition.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
